### PR TITLE
Add `require` as alias for `requireWithStubs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ define([
             bogus.stub('SteeringWheel', fakeSteeringWheel);
 
             // load Car module, that depends on SteeringWheel
-            bogus.requireWithStubs('Car', function(module){
+            bogus.require('Car', function(module){
                 Car = module;
                 done();
             });

--- a/bogus.js
+++ b/bogus.js
@@ -99,6 +99,7 @@ define(['require'], function(require){
 
     return {
         stub: stubOneOrMany,
+        require: requireWithStubs,
         requireWithStubs: requireWithStubs,
         reset: reset
     };

--- a/test/test.js
+++ b/test/test.js
@@ -113,6 +113,12 @@
             });
         });
 
+        describe('require method', function(){
+            it('should be an alias of requireWithStubs', function(){
+                assert.equal(bogus.require, bogus.requireWithStubs);
+            });
+        });
+
         describe('reset method', function(){
             it('should return all original implementations to their names', function(done){
                 var define = requirejs.define,


### PR DESCRIPTION
This PR adds a `require` method as an alias for `requireWithStubs`.