### PR TITLE
Return promises from requireWithStubs and reset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ define('Car', ['SteeringWheel'], function(SteeringWheel){
 
     Car.prototype.getSteeringWheelColor = function getSteeringWheelColor(){
         return this.steeringWheel.color;
-    }
+    };
 
     return Car;
 });
@@ -73,7 +73,7 @@ define([
 
         afterEach(function(done){
             bogus.reset(done);
-        })
+        });
 
         describe('Car', function(){
             describe('getSteeringWheelColor method', function(){
@@ -85,6 +85,29 @@ define([
             });
         });
     });
+});
+```
+
+### Promises
+
+Both `bogus.require` and `bogus.reset` return promises. The `beforeEach` and
+`afterEach` in the example above can be written as:
+
+```javascript
+beforeEach(function(){
+    var fakeSteeringWheel = function(){
+        this.color = 'blue';
+    };
+
+    bogus.stub('SteeringWheel', fakeSteeringWheel);
+
+    return bogus.require('Car').then(function(module){
+        Car = module;
+    });
+});
+
+afterEach(function(){
+    return bogus.reset();
 });
 ```
 

--- a/test/test.js
+++ b/test/test.js
@@ -111,6 +111,13 @@
             it('should be a function', function(){
                 assert(typeof bogus.requireWithStubs === 'function');
             });
+
+            it('should return a promise', function(){
+                var p = bogus.requireWithStubs('blah', function(){}, function(){});
+
+                assert.equal(typeof p.then, 'function');
+                assert.equal(typeof p.catch, 'function');
+            });
         });
 
         describe('require method', function(){
@@ -120,18 +127,22 @@
         });
 
         describe('reset method', function(){
-            it('should return all original implementations to their names', function(done){
-                var define = requirejs.define,
-                    modules = [],
-                    moduleNames = [],
-                    i, j, module,
-                    defineStub;
+            var modules;
+            var defineStub;
+
+            beforeEach(function(done){
+                var define = requirejs.define;
+                var i;
+                var moduleNames = [];
+                var module;
+
+                modules = [];
 
                 sandbox.stub(requirejs, 'defined', function(){
                     return true;
                 });
 
-                for (i = 0; i < 10; i++){
+                for (i = 0; i < 10; i++) {
                     module = {
                         name : getUniqueModuleName(),
                         originalImplementation : {name: 'original'},
@@ -146,19 +157,41 @@
                 }
 
                 defineStub = sandbox.spy(requirejs, 'define');
-                requirejs(moduleNames, function () {
-                    bogus.reset(function(){
-                        j = 0;
-                        modules.forEach(function(module, index){
-                            var call = defineStub.getCall(index);
 
-                            assert.equal(call.args[0], module.name);
-                            j++;
-                        });
+                requirejs(moduleNames, function(){
+                    done();
+                });
+            });
 
-                        assert.equal(j, modules.length);
+            it('is a function', function(){
+                assert.equal(typeof bogus.reset, 'function');
+            });
 
-                        done();
+            it('returns a promise', function(){
+                var p = bogus.reset();
+
+                assert.equal(typeof p.then, 'function');
+                assert.equal(typeof p.catch, 'function');
+            });
+
+            it('returns all original implementations to their names and call a callback', function(done){
+                bogus.reset(function(){
+                    modules.forEach(function(module, index){
+                        var call = defineStub.getCall(index);
+
+                        assert.equal(call.args[0], module.name);
+                    });
+
+                    done();
+                });
+            });
+
+            it('returns all original implementations to their names and resolves a returned promise', function(){
+                return bogus.reset().then(function(){
+                    modules.forEach(function(module, index){
+                        var call = defineStub.getCall(index);
+
+                        assert.equal(call.args[0], module.name);
                     });
                 });
             });


### PR DESCRIPTION
This is more a proposal than a pull request. If you are open to the idea, I'm happy to move it around and improve the tests. For example, I could make it so that `requireWithStubs` checks for a `callback` and returns a promise when it doesn't find one. I've gone with the simple approach below both for clarity and because I prefer not to check arguments for this kind of thing.

## Why?

Mocha allows one to return a promise as an alternative to calling a `done` callback. This means that instead of:

```javascript
let someModule;

before(function (done) {
    bogus.require('some-module', module => {
        someModule = module;
        done();
    });
});
```

you can do

```javascript
let someModule;

before(function () {
    return bogus.requireReturningPromise('some-module')
        .then(module => someModule = module);
});
```

This is sort of nice, but the feature really comes into its own in the future, or when run with babel:

```javascript
let someModule;

before(async function () {
    someModule = await bogus.requireReturningPromise('some-module');
});
```

# Update:

I've taken the `requireReturningPromise` method out and added code to make both `requireWithStubs` and `reset` return promises.